### PR TITLE
Use main clipboard

### DIFF
--- a/lua/nvim-github-linker.lua
+++ b/lua/nvim-github-linker.lua
@@ -64,7 +64,7 @@ function M.github_linker_command()
     end
 
     if vim.g.nvim_github_linker_copy_to_clipboard then
-        vim.fn.setreg("*", url)
+        vim.fn.setreg("+", url)
     else
         print(url)
     end


### PR DESCRIPTION
Current setup uses x11's "primary" clipboard, which is typically not bound to the standard CTRL-c/CTRL-v setup that people will use, but to the middle mouse button instead. Copying a link from vim using the keyboard and then having to use the mouse to paste it somewhere else feels weird, and kinda defeats the purpose of the whole plugin, in my opinion